### PR TITLE
feat(QInput, QChipsInput, QUploader): Add custom loading slot as QBtn

### DIFF
--- a/source/components/chips-input.md
+++ b/source/components/chips-input.md
@@ -33,6 +33,11 @@ framework: {
 
 <!-- On error state -->
 <q-chips-input v-model="model" error />
+
+<!-- With custom loading spinner -->
+<q-chips-input v-model="model">
+  <q-spinner-oval slot="loading" />
+</q-chips-input>
 ```
 
 > The model variable must be an Array.

--- a/source/components/input-textfield.md
+++ b/source/components/input-textfield.md
@@ -27,6 +27,11 @@ framework: {
   :max-height="100"
   rows="7"
 /><!-- max-height refers to pixels -->
+
+<!-- With custom loading spinner -->
+<q-input v-model="text">
+  <q-spinner-oval slot="loading" />
+</q-input>
 ```
 
 ## Vue Properties

--- a/source/components/uploader.md
+++ b/source/components/uploader.md
@@ -157,6 +157,20 @@ Examples:
 />
 ```
 
+### Custom Spinner
+By default, when the Uploader component is in `uploading` state, it displays the default theme spinner to indicate such state. It is possible to customize the spinner used by defining a `loading` slot, as below:
+
+```html
+<q-uploader
+  :url="url">
+  <!--
+      Notice slot="loading". This is optional.
+      If missing, the default theme spinner will be used.
+    -->
+  <q-spinner-bars slot="loading" />
+</q-uploader>
+```
+
 ## Vue Methods
 | Vue Method | Description |
 | --- | --- |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested with all Quasar themes
- [X] It's been tested on a Cordova (iOS, Android) app
- [X] It's been tested on a Electron app
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/dev/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR introduces the `loading` slot to components:
* `QInput`
* `QChipsInput`
* `QUploader`

It emulates the behaviour of `QBtn` of having a custom UI that indicates that the component is loading instead of the default theme `QSpinner`.  This keeps consistency of spinners when using custom `QSpinner.*` or any other way to indicate `loading` states.