### PR TITLE
Changed sort-method description in datatable.md

### DIFF
--- a/source/components/datatable.md
+++ b/source/components/datatable.md
@@ -101,7 +101,7 @@ The default values of the different QTable labels are taken care of by default t
 | `table-class` | String/Array/Object | Classes for the `<table>` tag itself. |
 | `filter` | String | Filter String for Table used by `filter-method()`. |
 | `filter-method` | Function | When you want a custom filtering method. See next sections for details. |
-| `sort-method` | Function | When you want a custom filtering method. See next sections for details. |
+| `sort-method` | Function | When you want a custom sorting method. See next sections for details. |
 | `binary-state-sort` | Boolean | (v0.17.11+) By default, sorting a column has 3 states (no sort, ascending, descending). By using this property it only allows 2 states (ascending, descending). |
 
 Label properties are by default defined in Quasar's i18n, but you can override them:


### PR DESCRIPTION
Changed one word in sort-method definition

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
