### PR TITLE
windows-build-tools exception

### DIFF
--- a/source/guide/electron-preparation.md
+++ b/source/guide/electron-preparation.md
@@ -35,6 +35,16 @@ The first item we need to check is our npm version and ensure that it is not out
 
 Once that is complete, we can then continue to setup the needed build tools. Using [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools), most of the dirty work is done for us. Installing this globally will in turn setup Visual C++ packages, Python, and more.
 
+## Note: April 2019
+In Powershell.exe (Run as Admin)
+`npm install --global windows-build-tools` seems to fail at the moment with errors pointing to python2 and vctools.
+
+You can get around this with Chocolatey. One-liner install:
+`Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
+
+and then run `choco upgrade python2 visualstudio2017-workload-vctools`
+## // End Note
+
 At this point things should successfully install, but if not then you will need a clean installation of Visual Studio. Please note that these are not problems with Quasar, but they are related to NPM and Windows.
 
 ## 2. Start Developing


### PR DESCRIPTION
Added alternative for `npm install --global windows-build-tools` failing to complete on Windows 10 (circa April 2019) by referencing the Chocolatey command, `choco upgrade python2 visualstudio2017-workload-vctools`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Provided documentation update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all major browsers

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
